### PR TITLE
add discord message for each deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,6 +30,28 @@ jobs:
         run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Deployment Success
+        # code reused from rjstone's discord webhook notify example
+        uses: rjstone/discord-webhook-notify@v1
+        if: success()
+        with:
+          severity: info
+          details: "Deployment succeeded: https://github.com/linglejack06/fso-pokedex/commit/${{github.sha}}"
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Deployment Failure
+        uses: rjstone/discord-webhook-notify@v1
+        if: failure()
+        with:
+          severity: error
+          details: "Deployment failed: https://github.com/linglejack06/fso-pokedex/commit/${{github.sha}} Caused failure"
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Deployment Cancelled
+        uses: rjstone/discord-webhook-notify@v1
+        if: cancelled()
+        with:
+          severity: warn
+          details: Deployment cancelled
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
   version_bump:
     needs: [simple_deployment_pipeline]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Utilize rjstone/discord-webhook-notify to send deployment messages to discord after each build.